### PR TITLE
Added option to display default Swagger UI (closes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Create a `docs.html` page like this:
 
 Now [localhost:3030/docs/](http://localhost:3030/docs/) will show the documentation in the browser using the Swagger UI.
 
+You can also use `uiIndex: true` to use the default [Swagger UI](http://swagger.io/swagger-ui/).
+
 ## License
 
 Copyright (c) 2016

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ import url from 'url';
 import serveStatic from 'serve-static';
 import * as utils from './utils';
 
+// Find node_modules root path
+let modulesRootPath = require.resolve('swagger-ui');
+modulesRootPath = modulesRootPath.substr(0, modulesRootPath.lastIndexOf('node_modules'));
+
 export default function init (config) {
   return function () {
     const app = this;
@@ -46,6 +50,13 @@ export default function init (config) {
             config.uiIndex(req, res);
           } else if (typeof config.uiIndex === 'string') {
             res.sendFile(config.uiIndex);
+          } else if (config.uiIndex === true) {
+            if (req.query.url) {
+              res.sendFile(path.join(modulesRootPath, 'node_modules/swagger-ui/dist/index.html'));
+            } else {
+              // Set swagger url (needed for default UI)
+              res.redirect('?url=' + encodeURI(config.docsPath));
+            }
           } else {
             res.json(rootDoc);
           }


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving: adds an option to use the default swagger ui instead of having to provide one
- [x] Are there any open issues that are related to this? #38 
- [x] Is this PR dependent on PRs in other repos? No

### Other Information

I used the default index directly from the `swagger-ui` package, so it can be automatically updated instead of having to have to manually fix in case of `swagger-ui` package updates.