### PR TITLE
Added config option to support api prefixing and versioning (fix #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,50 @@ Now [localhost:3030/docs/](http://localhost:3030/docs/) will show the documentat
 
 You can also use `uiIndex: true` to use the default [Swagger UI](http://swagger.io/swagger-ui/).
 
+### Prefixed routes
+
+If your are using versioned or prefixed routes for your API like `/api/<version>/users`, you can configure it using the
+`prefix` property so all your services don't end up in the same group. The value of the `prefix` property can be either
+a string or a RegEx.
+
+```js
+const app = feathers()
+  .use(bodyParser.json())
+  .use(bodyParser.urlencoded({ extended: true }))
+  .configure(rest())
+  .configure(swagger({
+    prefix: /api\/v\d\//,
+    docsPath: '/docs',
+    info: {
+      title: 'A test',
+      description: 'A description'
+    }
+  }))
+  .use('/api/v1/messages', messageService);
+
+app.listen(3030);
+```
+
+To display your API version alongside the service name, you can also define a `versionPrefix` to be extracted:
+```js
+const app = feathers()
+  .use(bodyParser.json())
+  .use(bodyParser.urlencoded({ extended: true }))
+  .configure(rest())
+  .configure(swagger({
+    prefix: /api\/v\d\//,
+    versionPrefix: /v\d/,
+    docsPath: '/docs',
+    info: {
+      title: 'A test',
+      description: 'A description'
+    }
+  }))
+  .use('/api/v1/messages', messageService);
+
+app.listen(3030);
+```
+
 ## License
 
 Copyright (c) 2016

--- a/src/index.js
+++ b/src/index.js
@@ -76,11 +76,14 @@ export default function init (config) {
       service.docs = service.docs || {};
 
       // Load documentation from service, if available.
-      const doc = service.docs;
-      const group = path.split('/');
-      const tag = path.indexOf('/') > -1 ? group[0] : path;
-      const model = path.indexOf('/') > -1 ? group[1] : path;
-      const security = {};
+      var doc = service.docs;
+      var version = path.match(config.versionPrefix);
+      version = version ? ' ' + version[0] : '';
+      var apiPath = path.replace(config.prefix, '');
+      var group = apiPath.split('/');
+      var tag = (apiPath.indexOf('/') > -1 ? group[0] : apiPath) + version;
+      var model = apiPath.indexOf('/') > -1 ? group[1] : apiPath;
+      var security = {};
 
       if (rootDoc.security) {
         security[rootDoc.security.name] = [];

--- a/src/index.js
+++ b/src/index.js
@@ -76,14 +76,14 @@ export default function init (config) {
       service.docs = service.docs || {};
 
       // Load documentation from service, if available.
-      var doc = service.docs;
-      var version = path.match(config.versionPrefix);
+      const doc = service.docs;
+      let version = path.match(config.versionPrefix);
       version = version ? ' ' + version[0] : '';
-      var apiPath = path.replace(config.prefix, '');
-      var group = apiPath.split('/');
-      var tag = (apiPath.indexOf('/') > -1 ? group[0] : apiPath) + version;
-      var model = apiPath.indexOf('/') > -1 ? group[1] : apiPath;
-      var security = {};
+      const apiPath = path.replace(config.prefix, '');
+      const group = apiPath.split('/');
+      const tag = (apiPath.indexOf('/') > -1 ? group[0] : apiPath) + version;
+      const model = apiPath.indexOf('/') > -1 ? group[1] : apiPath;
+      const security = {};
 
       if (rootDoc.security) {
         security[rootDoc.security.name] = [];


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving.
Adds config `prefix` and `versionPrefix` options to support API with prefixing/versioning.

- [x] Are there any open issues that are related to this? #39 
- [x] Is this PR dependent on PRs in other repos? No