### PR TITLE
Fix 'text/html' redirect not respecting mountpath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export default function init (config) {
           const pathname = parsed.pathname;
 
           if (pathname[pathname.length - 1] !== '/') {
-            parsed.pathname = `${pathname}/`;
+            parsed.pathname = `${req.baseUrl}${pathname}/`;
             return res.redirect(301, url.format(parsed));
           }
 


### PR DESCRIPTION
If the feathers app that this plugin is configured on is mounted at a prefixed URL, the redirect breaks.