### PR TITLE
Fix extra whitespace if no versionPrefix is passed in config.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ export default function init (config) {
 
       // Load documentation from service, if available.
       const doc = service.docs;
-      let version = path.match(config.versionPrefix);
+      let version = config.versionPrefix ? path.match(config.versionPrefix) : null;
       version = version ? ' ' + version[0] : '';
       const apiPath = path.replace(config.prefix, '');
       const group = apiPath.split('/');


### PR DESCRIPTION
If no versionPrefix is passed in the config, then things like tags in the docs will have extra whitespace. Like:

```js
{
  // ... stuff
  "tags": [
    {
      "name": "auth ", // <--- extra whitespace
      "description": "A auth service",
      "externalDocs": {}
    },
    {
      "name": "users ",  // <--- extra whitespace
      "description": "A users service",
      "externalDocs": {}
    }
  ],
  // ... more stuff
}
```