### PR TITLE
Allow each method of a service to define docs.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,7 @@ export function tag (name, options = {}) {
 }
 
 export function operation (method, service, defaults = {}) {
-  const operation = service.docs[method] || {};
+  const operation = Object.assign(service.docs[method] || {}, service[method].docs || {});
 
   operation.parameters = operation.parameters || defaults.parameters || [];
   operation.responses = operation.responses || defaults.responses || [];


### PR DESCRIPTION
Simple change that allows for an alternative syntax in services that in some cases would read better (IMO). Example (with a theoretical decorator that we could even ship):

```js
@docs({
  description: 'My cool service.'
})
class MyService {
  @docs({
    description: 'Create the cool thing.',
    parameters: [],
    responses: {}
  })
  create () {
    // Do the thing
  }

  @docs({
    description: 'Find cool things.',
    parameters: [],
    responses: {}
  })
  find () {
    // Do the thing
  }
}
```

Or just use getters in a clever fashion.

```js
class MyService {
  get docs () {
    return {
      description: 'My cool service.'
    }
  }

  get create () {
    return Object.assign(this._create, {
      docs: {
        description: 'Create the cool thing.',
        parameters: [],
        responses: {}
      }
    })
  }
  _create () {
    // Do the thing
  }

  get find () {
    return Object.assign(this._find, {
      docs: {
        description: 'Find cool things.',
        parameters: [],
        responses: {}
      }
    })
  }
  _find () {
    // Do the thing
  }
}
```