### PR TITLE
Quality of life

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,10 @@ export default function init (config) {
 
       if (typeof doc.definition !== 'undefined') {
         rootDoc.definitions[tag] = doc.definition;
+        rootDoc.definitions[`${tag} list`] = {
+          type: 'array',
+          items: doc.definition
+        };
       }
 
       if (typeof doc.definitions !== 'undefined') {
@@ -114,7 +118,18 @@ export default function init (config) {
         pathObj[withoutIdKey].get = utils.operation('find', service, {
           tags: [tag],
           description: 'Retrieves a list of all resources from the service.',
-
+          responses: {
+            '200': {
+              description: 'success',
+              schema: {'$ref': '#/definitions/' + `${tag} list`}
+            },
+            '500': {
+              description: 'general error'
+            },
+            '401': {
+              description: 'not authenticated'
+            }
+          },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('find') > -1 ? security : {}
@@ -134,6 +149,21 @@ export default function init (config) {
             name: idName,
             type: idType
           }],
+          responses: {
+            '200': {
+              description: 'success',
+              schema: {'$ref': '#/definitions/' + tag}
+            },
+            '500': {
+              description: 'general error'
+            },
+            '401': {
+              description: 'not authenticated'
+            },
+            '404': {
+              description: 'not found'
+            }
+          },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('get') > -1 ? security : {}
@@ -150,8 +180,19 @@ export default function init (config) {
             in: 'body',
             name: 'body',
             required: true,
-            schema: {'$ref': '#/definitions/' + model}
+            schema: {'$ref': '#/definitions/' + tag}
           }],
+          responses: {
+            '201': {
+              description: 'created'
+            },
+            '500': {
+              description: 'general error'
+            },
+            '401': {
+              description: 'not authenticated'
+            }
+          },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('create') > -1 ? security : {}
@@ -174,8 +215,23 @@ export default function init (config) {
             in: 'body',
             name: 'body',
             required: true,
-            schema: {'$ref': '#/definitions/' + model}
+            schema: {'$ref': '#/definitions/' + tag}
           }],
+          responses: {
+            '200': {
+              description: 'success',
+              schema: {'$ref': '#/definitions/' + tag}
+            },
+            '500': {
+              description: 'general error'
+            },
+            '401': {
+              description: 'not authenticated'
+            },
+            '404': {
+              description: 'not found'
+            }
+          },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('update') > -1 ? security : {}
@@ -198,8 +254,23 @@ export default function init (config) {
             in: 'body',
             name: 'body',
             required: true,
-            schema: {'$ref': '#/definitions/' + model}
+            schema: {'$ref': '#/definitions/' + tag}
           }],
+          responses: {
+            '200': {
+              description: 'success',
+              schema: {'$ref': '#/definitions/' + tag}
+            },
+            '500': {
+              description: 'general error'
+            },
+            '401': {
+              description: 'not authenticated'
+            },
+            '404': {
+              description: 'not found'
+            }
+          },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('patch') > -1 ? security : {}
@@ -219,6 +290,21 @@ export default function init (config) {
             name: idName,
             type: idType
           }],
+          responses: {
+            '200': {
+              description: 'success',
+              schema: {'$ref': '#/definitions/' + tag}
+            },
+            '500': {
+              description: 'general error'
+            },
+            '401': {
+              description: 'not authenticated'
+            },
+            '404': {
+              description: 'not found'
+            }
+          },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('remove') > -1 ? security : {}

--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,8 @@ export default function init (config) {
 
       // Load documentation from service, if available.
       const doc = service.docs;
+      const idName = service.id || 'id';
+      const idType = doc.idType || 'integer';
       let version = config.versionPrefix ? path.match(config.versionPrefix) : null;
       version = version ? ' ' + version[0] : '';
       const apiPath = path.replace(config.prefix, '');
@@ -94,10 +96,10 @@ export default function init (config) {
       }
 
       const pathObj = rootDoc.paths;
-      const withIdKey = `/${path}/{${service.id || 'id'}}`;
+      const withIdKey = `/${path}/{${idName}}`;
       const withoutIdKey = `/${path}`;
       const securities = doc.securities || [];
-      
+
       if (typeof doc.definition !== 'undefined') {
         rootDoc.definitions[tag] = doc.definition;
       }
@@ -112,6 +114,7 @@ export default function init (config) {
         pathObj[withoutIdKey].get = utils.operation('find', service, {
           tags: [tag],
           description: 'Retrieves a list of all resources from the service.',
+
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('find') > -1 ? security : {}
@@ -128,14 +131,9 @@ export default function init (config) {
             description: `ID of ${model} to return`,
             in: 'path',
             required: true,
-            name: 'resourceId',
-            type: 'integer'
+            name: idName,
+            type: idType
           }],
-          responses: {
-            '200': {
-              description: 'success'
-            }
-          },
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,
           security: securities.indexOf('get') > -1 ? security : {}
@@ -170,8 +168,8 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
-            type: 'integer'
+            name: idName,
+            type: idType
           }, {
             in: 'body',
             name: 'body',
@@ -194,8 +192,8 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
-            type: 'integer'
+            name: idName,
+            type: idType
           }, {
             in: 'body',
             name: 'body',
@@ -218,8 +216,8 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
-            type: 'integer'
+            name: idName,
+            type: idType
           }],
           produces: rootDoc.produces,
           consumes: rootDoc.consumes,

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,26 @@ export default function init (config) {
         pathObj[withoutIdKey].get = utils.operation('find', service, {
           tags: [tag],
           description: 'Retrieves a list of all resources from the service.',
+          parameters: [
+            {
+              description: 'Number of results to return',
+              in: 'query',
+              name: '$limit',
+              type: 'integer'
+            },
+            {
+              description: 'Number of results to skip',
+              in: 'query',
+              name: '$skip',
+              type: 'integer'
+            },
+            {
+              description: 'Property to sort results',
+              in: 'query',
+              name: '$sort',
+              type: 'string'
+            }
+          ],
           responses: {
             '200': {
               description: 'success',


### PR DESCRIPTION
I apologize. I was cleaning up my repo and deleted the branch, which closed the PR. here is the same PR as #64

Been trying to dig into Feathers recently, and like it very much so far! Found feathers-swagger, which made things even better. XD Found a bit of missing functionality, though.

As far as I can tell, this should fully backwards compatible.

1. The id names are fixed to `resourceId` (at least in the parameters, though the url is set properly). The type is also fixed at `integer`. The parameter name is now set the same way the URL was before, and the type still defaults to `integer`, but can be overwritten at `docs.idType`.

2. Only the getWithId endpoint had any responses defined, and only the 200, and with no schema. All endpoints have the appropriate responses (as far as I can tell), and off the appropriate schema (with a new list schema defined for the getWithoutId endpoint). Schema refs are also now build with the `tag` instead of `model`, the same place they were previously added if a `doc.definition` was present.

3. List parameters have been added for `$limit`, `$skip`, and `$sort`.