### PR TITLE
changing resourceId to correct interpolation for dynamic use

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ export default function init (config) {
       const withIdKey = `/${path}/{${service.id || 'id'}}`;
       const withoutIdKey = `/${path}`;
       const securities = doc.securities || [];
-      
+
       if (typeof doc.definition !== 'undefined') {
         rootDoc.definitions[tag] = doc.definition;
       }
@@ -128,7 +128,7 @@ export default function init (config) {
             description: `ID of ${model} to return`,
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }],
           responses: {
@@ -170,7 +170,7 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }, {
             in: 'body',
@@ -194,7 +194,7 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }, {
             in: 'body',
@@ -218,7 +218,7 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }],
           produces: rootDoc.produces,


### PR DESCRIPTION
### Summary
Minor tweak so that swagger-ui works as intended 

- [x] Tell us about the problem your pull request is solving. 
When using this library, the calls that require keys: get/{_id} do not work. this edits the swagger config to fix that.
- [x] Are there any open issues that are related to this?
#37 - they have not been active for a 2+ months and were suggesting a change to lib/index.js, which is the compiled version, not src/index.js - they might not be aware of the contributing guide
- [x] Is this PR dependent on PRs in other repos? 
No

If so, please mention them to keep the conversations linked together.

