### PR TITLE
Sequelize example runnable

### DIFF
--- a/example/sequelize/app.js
+++ b/example/sequelize/app.js
@@ -5,7 +5,9 @@ const service = require('feathers-sequelize');
 const cors = require('cors');
 const path = require('path');
 const hooks = require('feathers-hooks');
+const { discard } = require('feathers-hooks-common');
 const authentication = require('feathers-authentication');
+const { hashPassword } = require('feathers-authentication-local').hooks;
 const Sequelize = require('sequelize');
 const user = require('./user-model');
 const bodyParser = require('body-parser');
@@ -100,6 +102,7 @@ app.options('*', cors())
       'token': {
         'secret': '7RJeSzXr2n/Mb15vl1lVAUs7PHNjvlV3ltJLpBjdJ93MPanV1HkFf5WjK/J4V2hqFaxALsPrqr7cgBPsA0M0DQ=='
       },
+      'secret': 'thisIsRequiredForSequelizeExampleToRunButIDoNotKnowWhatItDoes',
       'local': {}
     };
     app.configure(authentication(config));
@@ -155,15 +158,15 @@ app.options('*', cors())
     const userService = this.service('/users');
     const auth = authentication.hooks;
     userService.before({
-      create: [auth.hashPassword()],
+      create: [hashPassword()],
       find: [
-        auth.verifyToken(),
-        auth.populateUser(),
-        auth.restrictToAuthenticated()
+        // auth.verifyToken(), //need migrating to new authentication?
+        // auth.populateUser(),
+        // auth.restrictToAuthenticated()
       ]
     });
     userService.after({
-      all: [hooks.remove('password')]
+      all: [discard('password')]
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "mocha": "mocha --opts mocha.opts",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "test": "npm run compile && npm run lint && npm run coverage",
-    "start": "npm run compile && node example/simple/app"
+    "start": "npm run compile && node example/simple/app",
+    "example2": "npm run compile && node example/sequelize/app"
   },
   "semistandard": {
     "sourceType": "module",
@@ -70,6 +71,9 @@
     "cors": "^2.8.1",
     "feathers": "^2.0.2",
     "feathers-authentication": "^1.0.2",
+    "feathers-authentication-local": "^0.3.4",
+    "feathers-hooks": "^2.0.1",
+    "feathers-hooks-common": "^3.5.1",
     "feathers-memory": "^1.0.1",
     "feathers-rest": "^1.5.2",
     "feathers-sequelize": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ export default function init (config) {
       const withIdKey = `/${path}/{${service.id || 'id'}}`;
       const withoutIdKey = `/${path}`;
       const securities = doc.securities || [];
-      
+
       if (typeof doc.definition !== 'undefined') {
         rootDoc.definitions[tag] = doc.definition;
       }
@@ -128,7 +128,7 @@ export default function init (config) {
             description: `ID of ${model} to return`,
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }],
           responses: {
@@ -170,7 +170,7 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }, {
             in: 'body',
@@ -194,7 +194,7 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }, {
             in: 'body',
@@ -218,7 +218,7 @@ export default function init (config) {
             description: 'ID of ' + model + ' to return',
             in: 'path',
             required: true,
-            name: 'resourceId',
+            name: `${service.id || 'id'}`,
             type: 'integer'
           }],
           produces: rootDoc.produces,


### PR DESCRIPTION
### Summary

I think the /examples/sequelize/app.js example is super useful and showcases a ton of stuff, unfortunately I think it needs updating (migrating?) to more recent versions of hooks so it runs out of the box. I'm not certain the best way to fix the authentication issues, since I'm not yet familiar with the hooks ecosystem

- [x] Tell us about the problem your pull request is solving.
Exposing another example, allowing `npm run example2` to work out of the box and run sequelize example
- [x] Are there any open issues that are related to this?
not that I'm aware of
- [x] Is this PR dependent on PRs in other repos?
currently after my other pr #72 , but doesn't rely on it 